### PR TITLE
Fix token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Coupa Kafka OAuth2 Library
+# Kafka OAuth2 Library
 
-### Container Environments
-For client broker authentication, configure this environment variable:
+### Sand Config File
+Configure this environment variable to a path of file containing SAND configs.
 
-- KAFKA_SAND_CONFIG_PATH: path to properties file which holds config for sand server.
+- KAFKA_SAND_CONFIG_PATH: path to properties file which holds config for sand server. Defaults: /etc/kafka/sand.properties
 
-### Kafka Sand Client Configuration (Producer/Consumer)
-Add this properties in your kafka configuration
+### Kafka-Sand Configuration
+Add the below properties in your SAND configs file(KAFKA_SAND_CONFIG_PATH)
 
 ```
 sand.server.url=FIXME
@@ -24,18 +24,24 @@ sand.service.action=any
 ### Example (Producer)
 
 ```bash
-export KAFKA_SAND_CONFIG_PATH=/home/deploy/sand.properties
-KAFKA_OPTS="-Dlog4j.configuration=file:/srv/kafka/2.12-2.0.0/kafka_2.12-2.0.0/config/log4j.properties  -Djava.security.properties=/etc/kafka/bcfips.java.security -Djavax.net.ssl.trustStore=/var/private/ssl/kafka.truststore.bcfks -Djavax.net.ssl.trustStorePassword=some_password" /srv/kafka/current/kafka_2.12-2.0.0/bin/kafka-console-producer.sh --broker-list 10.1.11.43:9092 --producer.config client.properties --topic test-topic1
+export KAFKA_SAND_CONFIG_PATH=/etc/kafka/sand.properties
+sudo KAFKA_OPTS="-Dlog4j.configuration=file:/srv/kafka/2.12-2.0.0/kafka_2.12-2.0.0/config/log4j.properties -Djava.security.properties=/etc/kafka/bcfips.java.security -Djavax.net.ssl.trustStore=/var/private/ssl/kafka.truststore.bcfks -Djavax.net.ssl.trustStorePassword=<trustStorePasswordHere>" /srv/kafka/current/kafka_2.12-2.0.0/bin/kafka-console-producer.sh --broker-list <broker_ip>:9092 --producer.config client.properties --topic test-topic1
 ```
 
-## Broker X Broker Authentication
-```java
-class com.coupa.kafka.security.sasl.oauth.KafkaBrokerTokenCreator
-```
-### How to build/package the library.
 
-```bash
-mvn3/maven/mvn package
+# Client Properties
+client.properties should contains content like below:
+```
+security.protocol=SASL_SSL
+ssl.truststore.location=<path_to_truststore>
+ssl.truststore.password=<truststore_password>
+ssl.endpoint.identification.algorithm=
+sasl.mechanism=OAUTHBEARER
+ssl.truststore.type = BCFKS/JKS
+ssl.keystore.type = BCFKS/JKS
+ssl.secure.random.implementation=DEFAULT
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+sasl.login.callback.handler.class=com.coupa.kafka.security.sasl.oauth.KafkaBrokerTokenCreator
 ```
 
 ### Kafka Server Configuration
@@ -58,6 +64,11 @@ Add this properties in server.properties
         org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ;
     };
     ```
-2. Add this file to config path of kafka.
+2. Add this file to config path of kafka. Add `-Djava.security.auth.login.config=<path_to_kafka_server_jaas.conf>` at java args to load the configuration file.
 
-3. Add `-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf` at java args to load the configuration file.
+
+### How to build/package the library.
+
+```bash
+mvn3/maven/mvn package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@
             <version>4.5.8</version>
         </dependency>
         <dependency>
-		    <groupId>com.github.coupa</groupId>
-		    <artifactId>sand-java</artifactId>
-		    <version>1.1.0</version>
-		</dependency>
+            <groupId>com.github.coupa</groupId>
+            <artifactId>sand-java</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -54,7 +54,6 @@
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <artifactSet>
                       <excludes>
-                          <exclude>org.apache.*:*:*</exclude>
                           <exclude>org.slf4j:*:*</exclude>
                           <exclude>com.fasterxml.*:*:*</exclude>
                           <exclude>org.lz4:lz4-java:*</exclude>

--- a/src/main/java/com/coupa/kafka/security/sasl/oauth/KafkaBrokerTokenCreator.java
+++ b/src/main/java/com/coupa/kafka/security/sasl/oauth/KafkaBrokerTokenCreator.java
@@ -29,7 +29,7 @@ public class KafkaBrokerTokenCreator implements AuthenticateCallbackHandler {
 
   @Override
   public void configure(Map<String, ?> configs, String saslMechanism,
-                        List<AppConfigurationEntry> jaasConfigEntries)  {
+      List<AppConfigurationEntry> jaasConfigEntries)  {
 
     SandConfig.configure(saslMechanism, jaasConfigEntries);
     LOGGER.info("Configured Kafka broker oauth token creator successfully");
@@ -42,7 +42,6 @@ public class KafkaBrokerTokenCreator implements AuthenticateCallbackHandler {
   @Override
   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
     for (Callback callback : callbacks) {
-
       if (callback instanceof OAuthBearerTokenCallback) {
         makeToken((OAuthBearerTokenCallback) callback);
       } else {
@@ -60,16 +59,18 @@ public class KafkaBrokerTokenCreator implements AuthenticateCallbackHandler {
 
     LOGGER.info("Getting token from SAND");
     TokenResponse tokenResponse = sand.getService().getOAuthToken(
-            SandConfig.SAND_CLIENT_CACHE_KEY,
-            sand.getArray(SandConfig.SAND_CLIENT_SCOPES),
-            SandConfig.SAND_RETRY_COUNT);
+        SandConfig.SAND_CLIENT_CACHE_KEY,
+        sand.getArray(SandConfig.SAND_CLIENT_SCOPES),
+        SandConfig.SAND_RETRY_COUNT);
 
     if (tokenResponse == null) {
       throw new IllegalArgumentException("Failed to get token from SAND");
     }
     LOGGER.debug("Token received: {}", tokenResponse.getToken());
 
-    callback.token(new SandOAuthToken(sand.getService().getClientId().toString(), tokenResponse));
+    SandOAuthToken tk = new SandOAuthToken(sand.getService().getClientId().toString(), tokenResponse);
+    LOGGER.debug(tk.toString());
+    callback.token(tk);
   }
 
 }

--- a/src/main/java/com/coupa/kafka/security/sasl/oauth/SandConfig.java
+++ b/src/main/java/com/coupa/kafka/security/sasl/oauth/SandConfig.java
@@ -59,7 +59,7 @@ public class SandConfig {
       return theInstance;
   }
 
-  public static boolean configure(String saslMechanism,
+  public static void configure(String saslMechanism,
                                   List<AppConfigurationEntry> jaasConfigEntries) {
 
     if (!OAUTHBEARER_MECHANISM.equals(saslMechanism)) {
@@ -79,8 +79,6 @@ public class SandConfig {
           String.format("Must supply exactly 1 non-null JAAS mechanism configuration (size was %d)",
               jaasConfigEntries.size()));
     }
-
-    return true;
   }
 
   public Service getService() {

--- a/src/main/java/com/coupa/kafka/security/sasl/oauth/SandOAuthToken.java
+++ b/src/main/java/com/coupa/kafka/security/sasl/oauth/SandOAuthToken.java
@@ -19,14 +19,17 @@ import com.coupa.sand.TokenResponse;
 
 public class SandOAuthToken implements OAuthBearerToken {
   private String token;
-  private Set<String> scope;
-  private long lifetimeMs;
-  private String principalName;
-  private Long startTimeMs;
+  private Set<String> scope = new TreeSet<String>();
+  private long lifetimeMs = 0L;
+  private String principalName = "";
+  private Long startTimeMs = 0L;
 
 
   public SandOAuthToken(String token, AllowedResponse resp) {
     this.token = token;
+    if (!resp.isAllowed()) {
+      return;
+    }
     scope = new TreeSet<String>(Arrays.asList(resp.getScopes()));
     principalName = resp.getSub();
 
@@ -42,6 +45,10 @@ public class SandOAuthToken implements OAuthBearerToken {
   public SandOAuthToken(String clientID, TokenResponse resp) {
     token = resp.getToken();
     principalName = clientID;
+    scope = new TreeSet<String>(Arrays.asList(resp.getScopes()));
+    
+    startTimeMs = Instant.now().toEpochMilli();
+    lifetimeMs = startTimeMs + resp.getExpiresIn() * 1_000L;
   }
 
   @Override
@@ -72,10 +79,11 @@ public class SandOAuthToken implements OAuthBearerToken {
   @Override
   public String toString() {
     return "SandOAuthToken{" +
-        "value='" + token + '\'' +
-        ", lifetimeMs=" + lifetimeMs +
-        ", principalName='" + principalName + '\'' +
-        ", startTimeMs=" + startTimeMs +
+        "value='" + value() + '\'' +
+        ", lifetimeMs=" + lifetimeMs() +
+        ", principalName='" + principalName() + '\'' +
+        ", startTimeMs=" + startTimeMs() +
+        ", scope=" + scope() +
         '}';
   }
 }


### PR DESCRIPTION
Token validation was failing because the use of the "error" method on the callback.

Fixed by removing the method and call `OAuthBearerValidationResult.newFailure` to mark failure.
