### PR TITLE
Upgrade kafka library to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.coupa.cloud.operations.ce</groupId>
     <artifactId>kafka-oauth</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -20,8 +20,8 @@
         <!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.12</artifactId>
-            <version>2.0.0</version>
+            <artifactId>kafka_2.13</artifactId>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
It is reported that we need to upgrade kafka library to 2.7.0, so updating it accordingly. See CE-13653

- [ ] @johnny-lai 